### PR TITLE
Added the ability to expose Buffer and Index Data in Tw2GeometryMeshes

### DIFF
--- a/src/core/Tw2GeometryRes.js
+++ b/src/core/Tw2GeometryRes.js
@@ -343,7 +343,7 @@ function Tw2GeometryRes()
     this.boundsSphereRadius = 0;
     this.models = [];
     this.animations = [];
-    this.systemMirror = false;
+    this.systemMirror = resMan.systemMirror;
 }
 
 /**

--- a/src/core/Tw2ResMan.js
+++ b/src/core/Tw2ResMan.js
@@ -206,6 +206,7 @@ Inherit(Tw2LoadingObject, Tw2Resource);
 
 /**
  * Resource Manager
+ * @property {boolean} systemMirror - Toggles whether {@link GeometryResource} Index and Buffer data arrays are visible
  * @property {Object.<string, string>} resourcePaths
  * @property {Object} resourcePaths.res - Default resource path for current ccpwgl version
  * @property {Object.<string, Function>} _extensions - an object of registered extensions and their constructors
@@ -225,6 +226,7 @@ Inherit(Tw2LoadingObject, Tw2Resource);
  */
 function Tw2ResMan()
 {
+    this.systemMirror = false;
     this.resourcePaths = {};
 
     this.resourcePaths['res'] = '//developers.eveonline.com/ccpwgl/assetpath/1005132/';


### PR DESCRIPTION
- Added @type boolean @property 'systemMirror' to `Tw2ResMan` which allows developers to expose `Tw2GeometryResource`'s `Tw2GeometryMesh` `indexData` and `bufferData` float32arrays 

- Updated the @property `systemMirror` in `Tw2GeometryRes` so that it uses the value set in the global `resMan` object. (This must be set before an space object is built).