### PR TITLE
Minor Fixes and Basic Documentation Tw2EveBoosterSet

### DIFF
--- a/src/eve/EveBoosterSet.js
+++ b/src/eve/EveBoosterSet.js
@@ -1,24 +1,47 @@
+/**
+ * EveBoosterSet
+ * @property {boolean} display
+ * @property {Tw2Effect} effect
+ * @property {Tw2Effect} glows
+ * @property {number} glowScale
+ * @property {quat4} glowColor
+ * @property {quat4} warpGlowColor
+ * @property {number} symHaloScale
+ * @property {number} haloScaleX
+ * @property {number} haloScaleY
+ * @property {number} maxVel
+ * @property {quat4} haloColor
+ * @property {boolean} alwaysOn
+ * @property {mat4} _parentTransform
+ * @property {mat4} _wavePhase
+ * @property {Array.<{}>} _boosterTransforms
+ * @property {WebGlBuffer} _positions
+ * @property {Tw2VertexDeclaration} _decl
+ * @property {Tw2PerObjectData} _perObjectData
+ * @property {boolean} rebuildPending
+ * @constructor
+ */
 function EveBoosterSet()
 {
     this.display = true;
     this.effect = null;
     this.glows = null;
     this.glowScale = 1.0;
-    this.glowColor = [0, 0, 0, 0];
-    this.warpGlowColor = [0, 0, 0, 0];
+    this.glowColor = quat4.create();
+    this.warpGlowColor = quat4.create();
     this.symHaloScale = 1.0;
     this.haloScaleX = 1.0;
     this.haloScaleY = 1.0;
     this.maxVel = 250;
-    this.haloColor = [0, 0, 0, 0];
+    this.haloColor = quat4.create();
     this.alwaysOn = true;
-    
+
     this._parentTransform = mat4.create();
-    this._wavePhase = [];
+    this._wavePhase = mat4.create();
     this._boosterTransforms = [];
-    
+
     this._positions = device.gl.createBuffer();
-    
+
     this._decl = new Tw2VertexDeclaration();
     this._decl.elements.push(new Tw2VertexElement(Tw2VertexDeclaration.DECL_POSITION, 0, device.gl.FLOAT, 3, 0));
     this._decl.elements.push(new Tw2VertexElement(Tw2VertexDeclaration.DECL_TEXCOORD, 0, device.gl.FLOAT, 2, 12));
@@ -30,22 +53,28 @@ function EveBoosterSet()
     this._decl.elements.push(new Tw2VertexElement(Tw2VertexDeclaration.DECL_TEXCOORD, 6, device.gl.FLOAT, 1, 100));
     this._decl.elements.push(new Tw2VertexElement(Tw2VertexDeclaration.DECL_TEXCOORD, 7, device.gl.FLOAT, 2, 104));
     this._decl.RebuildHash();
-    
+
     this._perObjectData = new Tw2PerObjectData();
     this._perObjectData.perObjectVSData = new Tw2RawData();
     this._perObjectData.perObjectVSData.Declare('WorldMat', 16);
     this._perObjectData.perObjectVSData.Declare('Shipdata', 4);
     this._perObjectData.perObjectVSData.Create();
-    
+
     this.rebuildPending = false;
 }
 
-EveBoosterSet.prototype.Initialize = function ()
+/**
+ * Initializes the booster set
+ */
+EveBoosterSet.prototype.Initialize = function()
 {
     this.rebuildPending = true;
 };
 
-EveBoosterSet.prototype.Clear = function ()
+/**
+ * Clears the booster set
+ */
+EveBoosterSet.prototype.Clear = function()
 {
     this._boosterTransforms = [];
     this._wavePhase = mat4.create();
@@ -55,11 +84,22 @@ EveBoosterSet.prototype.Clear = function ()
     }
 };
 
-EveBoosterSet.prototype.Add = function (localMatrix, atlas0, atlas1)
+/**
+ * Adds a booster
+ * @param {mat4} localMatrix
+ * @param {number} atlas0
+ * @param {number} atlas1
+ * @constructor
+ */
+EveBoosterSet.prototype.Add = function(localMatrix, atlas0, atlas1)
 {
     var transform = mat4.create();
     mat4.set(localMatrix, transform);
-    this._boosterTransforms[this._boosterTransforms.length] = {transform: transform, atlas0: atlas0, atlas1: atlas1};
+    this._boosterTransforms[this._boosterTransforms.length] = {
+        transform: transform,
+        atlas0: atlas0,
+        atlas1: atlas1
+    };
     this._wavePhase[this._wavePhase.length] = Math.random();
     if (this.glows)
     {
@@ -67,7 +107,8 @@ EveBoosterSet.prototype.Add = function (localMatrix, atlas0, atlas1)
         var dir = vec3.create([localMatrix[8], localMatrix[9], localMatrix[10]]);
         var scale = Math.max(vec3.length([localMatrix[0], localMatrix[1], localMatrix[2]]), vec3.length([localMatrix[4], localMatrix[5], localMatrix[6]]));
         vec3.normalize(dir);
-        if (scale < 3) {
+        if (scale < 3)
+        {
             vec3.scale(dir, scale / 3);
         }
         var seed = Math.random() * 0.7;
@@ -81,49 +122,69 @@ EveBoosterSet.prototype.Add = function (localMatrix, atlas0, atlas1)
     }
 };
 
+/**
+ * Internal helper
+ * @type {Array}
+ * @private
+ */
 EveBoosterSet._box = [
-    [[-1.0, -1.0, 0.0],
-    [1.0, -1.0, 0.0],
-    [1.0, 1.0, 0.0],
-    [-1.0, 1.0, 0.0]],
+    [
+        [-1.0, -1.0, 0.0],
+        [1.0, -1.0, 0.0],
+        [1.0, 1.0, 0.0],
+        [-1.0, 1.0, 0.0]
+    ],
 
-    [[-1.0, -1.0, -1.0],
-    [-1.0, 1.0, -1.0],
-    [1.0, 1.0, -1.0],
-    [1.0, -1.0, -1.0]],
+    [
+        [-1.0, -1.0, -1.0],
+        [-1.0, 1.0, -1.0],
+        [1.0, 1.0, -1.0],
+        [1.0, -1.0, -1.0]
+    ],
 
-    [[-1.0, -1.0, 0.0],
-    [-1.0, 1.0, 0.0],
-    [-1.0, 1.0, -1.0],
-    [-1.0, -1.0, -1.0]],
+    [
+        [-1.0, -1.0, 0.0],
+        [-1.0, 1.0, 0.0],
+        [-1.0, 1.0, -1.0],
+        [-1.0, -1.0, -1.0]
+    ],
 
-    [[1.0, -1.0, 0.0],
-    [1.0, -1.0, -1.0],
-    [1.0, 1.0, -1.0],
-    [1.0, 1.0, 0.0]],
+    [
+        [1.0, -1.0, 0.0],
+        [1.0, -1.0, -1.0],
+        [1.0, 1.0, -1.0],
+        [1.0, 1.0, 0.0]
+    ],
 
-    [[-1.0, -1.0, 0.0],
-    [-1.0, -1.0, -1.0],
-    [1.0, -1.0, -1.0],
-    [1.0, -1.0, 0.0]],
+    [
+        [-1.0, -1.0, 0.0],
+        [-1.0, -1.0, -1.0],
+        [1.0, -1.0, -1.0],
+        [1.0, -1.0, 0.0]
+    ],
 
-    [[-1.0, 1.0, 0.0],
-    [1.0, 1.0, 0.0],
-    [1.0, 1.0, -1.0],
-    [-1.0, 1.0, -1.0]]
+    [
+        [-1.0, 1.0, 0.0],
+        [1.0, 1.0, 0.0],
+        [1.0, 1.0, -1.0],
+        [-1.0, 1.0, -1.0]
+    ]
 ];
 
-EveBoosterSet.prototype.Rebuild = function ()
+/**
+ * Rebuilds the boosters
+ */
+EveBoosterSet.prototype.Rebuild = function()
 {
     var data = new Float32Array(this._boosterTransforms.length * EveBoosterSet._box.length * 6 * 28);
     var order = [0, 3, 1, 3, 2, 1];
     var index = 0;
     for (var booster = 0; booster < this._boosterTransforms.length; ++booster)
     {
-        var vec = vec3.create();
-
-        for (var i = 0; i < EveBoosterSet._box.length; ++i) {
-            for (var j = 0; j < order.length; ++j) {
+        for (var i = 0; i < EveBoosterSet._box.length; ++i)
+        {
+            for (var j = 0; j < order.length; ++j)
+            {
                 data[index++] = EveBoosterSet._box[i][order[j]][0];
                 data[index++] = EveBoosterSet._box[i][order[j]][1];
                 data[index++] = EveBoosterSet._box[i][order[j]][2];
@@ -151,7 +212,13 @@ EveBoosterSet.prototype.Rebuild = function ()
     }
 };
 
-EveBoosterSet.prototype.Update = function (dt, parentMatrix)
+/**
+ * Per frame update
+ * @param {number} dt - DeltaTime
+ * @param {mat4} parentMatrix
+ * @constructor
+ */
+EveBoosterSet.prototype.Update = function(dt, parentMatrix)
 {
     if (this.glows)
     {
@@ -160,19 +227,34 @@ EveBoosterSet.prototype.Update = function (dt, parentMatrix)
     this._parentTransform = parentMatrix;
 };
 
+
+/**
+ * Booster render batch
+ * @constructor
+ */
 function EveBoosterBatch()
 {
-	this.renderMode = device.RM_ANY;
-	this.perObjectData = null;
-	this.boosters = null;
+    this.renderMode = device.RM_ANY;
+    this.perObjectData = null;
+    this.boosters = null;
 }
 
-EveBoosterBatch.prototype.Commit = function (overrideEffect)
+/**
+ * Commits the batch
+ * @param {Tw2Effect} [overrideEffect]
+ */
+EveBoosterBatch.prototype.Commit = function(overrideEffect)
 {
     this.boosters.Render(overrideEffect);
 };
 
-EveBoosterSet.prototype.GetBatches = function (mode, accumulator, perObjectData)
+/**
+ * Gets render batches
+ * @param {RenderMode} mode
+ * @param {Tw2BatchAccumulator} accumulator
+ * @param {Tw2PerObjectData} perObjectData
+ */
+EveBoosterSet.prototype.GetBatches = function(mode, accumulator, perObjectData)
 {
     if (!this.display || mode != device.RM_ADDITIVE)
     {
@@ -181,7 +263,7 @@ EveBoosterSet.prototype.GetBatches = function (mode, accumulator, perObjectData)
     if (this.effect && this._boosterTransforms.length)
     {
         var batch = new EveBoosterBatch();
-        
+
         mat4.transpose(this._parentTransform, this._perObjectData.perObjectVSData.Get('WorldMat'));
         this._perObjectData.perObjectVSData.Set('Shipdata', perObjectData.perObjectVSData.Get('Shipdata'));
         this._perObjectData.perObjectPSData = perObjectData.perObjectPSData;
@@ -196,9 +278,14 @@ EveBoosterSet.prototype.GetBatches = function (mode, accumulator, perObjectData)
     }
 };
 
-EveBoosterSet.prototype.Render = function (overrideEffect)
+/**
+ * Renders the accumulated batches
+ * @param {Tw2Effect} [overrideEffect]
+ * @returns {boolean}
+ */
+EveBoosterSet.prototype.Render = function(overrideEffect)
 {
-    var effect = typeof (overrideEffect) == 'undefined' ? this.effect : overrideEffect;
+    var effect = typeof(overrideEffect) == 'undefined' ? this.effect : overrideEffect;
     var effectRes = effect.GetEffectRes();
     if (!effectRes.IsGood())
     {


### PR DESCRIPTION
- Added basic documentation to `Tw2EveBoosterSet` and `Tw2EveBoosterBatch`
- fixed @properties that were arrays and should be initialized with `quat4.create()` and `mat4.create();
- removed redundant `vec3` variable from a @prototype